### PR TITLE
Add mime-types gem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,3 +19,4 @@ gem "middleman-search_engine_sitemap", "~> 1.4"
 
 # https://github.com/fredjean/middleman-s3_sync
 gem "middleman-s3_sync", "~> 4.0"
+gem "mime-types", "~> 3.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,6 +116,9 @@ GEM
     middleman-search_engine_sitemap (1.4.0)
       builder
       middleman-core (~> 4.0)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
     mini_portile2 (2.0.0)
     minitest (5.9.0)
     multi_json (1.12.1)
@@ -169,8 +172,9 @@ DEPENDENCIES
   middleman-pry
   middleman-s3_sync (~> 4.0)
   middleman-search_engine_sitemap (~> 1.4)
+  mime-types (~> 3.0)
   neat (~> 1.7)
-  sassc (~> 1.8)
+  sassc (~> 1.9)
 
 BUNDLED WITH
    1.11.2


### PR DESCRIPTION
This resolves the issue with `fog-core` and `middleman-s3_sync` which caused [Build #10](https://travis-ci.org/joshukraine/euroteamoutreach.org/builds/133094628) to fail. The error message was "[fog][WARNING] 'mime-types' missing, please install and try again."

